### PR TITLE
Update XUnit dependencies to exclude 2.0.

### DIFF
--- a/src/Socres.FakingEasy/Socres.FakingEasy.nuspec
+++ b/src/Socres.FakingEasy/Socres.FakingEasy.nuspec
@@ -15,8 +15,8 @@ These attributes combine FakeItEasy, xUnit and AutoFixture.</description>
             <dependency id="AutoFixture.AutoFakeItEasy" version="3.21.1" />
             <dependency id="AutoFixture.Xunit" version="3.21.1" />
             <dependency id="FakeItEasy" version="1.25.1" />
-            <dependency id="xunit" version="1.9.2" />
-            <dependency id="xunit.extensions" version="1.9.2" />
+            <dependency id="xunit" version="(1.9.2,2.0)" />
+            <dependency id="xunit.extensions" version="(1.9.2,2.0)" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
AutoFixture.XUnit does not support XUnit 2.0 yet. Until then we exclude
that version.